### PR TITLE
bump aws provider version to fix conflict

### DIFF
--- a/aws/modules/infrastructure/provider.tf
+++ b/aws/modules/infrastructure/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.65.0"
+      version = "3.73.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/aws/modules/infrastructure/rds.tf
+++ b/aws/modules/infrastructure/rds.tf
@@ -101,7 +101,7 @@ module "airflow_db" {
   family = "postgres13"
 
   # DB option group
-  major_engine_version = "13.4"
+  major_engine_version = "13.7"
 
   # Database Deletion Protection
   deletion_protection = true
@@ -119,7 +119,7 @@ module "superset_db" {
   identifier = "supersetdb"
 
   engine            = "postgres"
-  engine_version    = "13.4"
+  engine_version    = "13.7"
   instance_class    = "db.t4g.micro"
   allocated_storage = 10
 
@@ -149,7 +149,7 @@ module "superset_db" {
   family = "postgres13"
 
   # DB option group
-  major_engine_version = "13.4"
+  major_engine_version = "13.7"
 
   # Database Deletion Protection
   deletion_protection = true

--- a/aws/modules/infrastructure/rds.tf
+++ b/aws/modules/infrastructure/rds.tf
@@ -23,7 +23,7 @@ module "db" {
   identifier = "meltanodb"
 
   engine            = "postgres"
-  engine_version    = "13.4"
+  engine_version    = "13.7"
   instance_class    = "db.t4g.micro"
   allocated_storage = 10
 
@@ -53,7 +53,7 @@ module "db" {
   family = "postgres13"
 
   # DB option group
-  major_engine_version = "13.4"
+  major_engine_version = "13.7"
 
   # Database Deletion Protection
   deletion_protection = true
@@ -71,7 +71,7 @@ module "airflow_db" {
   identifier = "airflowdb"
 
   engine            = "postgres"
-  engine_version    = "13.4"
+  engine_version    = "13.7"
   instance_class    = "db.t4g.micro"
   allocated_storage = 10
 


### PR DESCRIPTION
@kgpayne @aaronsteers I can't init the module because of conflicting version constraints:

```
╷
│ Error: Failed to query available provider packages
│ 
│ Could not retrieve the list of available versions for provider hashicorp/aws: locked provider registry.terraform.io/hashicorp/aws 3.73.0 does not match configured
│ version constraint >= 2.49.0, >= 3.0.0, >= 3.1.0, >= 3.13.0, >= 3.40.0, >= 3.56.0, >= 3.59.0, 3.65.0, >= 3.73.0, < 4.0.0; must use terraform init -upgrade to allow
│ selection of new versions
```

The [squared module references](https://github.com/meltano/squared/blob/a90c111731c28c11c50111bc162a1d67d1221f71/deploy/infrastructure/main.tf#L18) the `v0.1.0` release and `main` has a bunch of name changes that we dont want to apply to squared right now. Could we create a new patch release to fix this?

Additionally it looks like the db versions were auto upgraded so when running an apply I get warnings that it cant downgrade my db from 13.7 to 13.4. This feels like the wrong place to do it since its specific to my deployment but wanted to see what you thought.